### PR TITLE
Added get_per_month to get month based consumption data for a given year.

### DIFF
--- a/pyeloverblik/__main__.py
+++ b/pyeloverblik/__main__.py
@@ -2,6 +2,7 @@
 Main for pyeloverblik
 '''
 import argparse
+from datetime import datetime
 import logging
 from . import Eloverblik
 
@@ -22,12 +23,23 @@ def main():
     if result.status == 200:
         total = 0
         print(f"Date: {result.data_date}")
-        for hour in range(24):
-            data = result.get_metering_data(hour)
+        for month in range(24):
+            data = result.get_metering_data(month)
             total += data
-            print(f"Hour {hour}-{hour+1}: {data}kWh")
+            print(f"Hour {month}-{month+1}: {data}kWh")
 
         print(f"Total: {total}kWh")
+    else:
+        print(f"Error getting data. Status: {result.status}. Error: {result.detailed_status}")
+    
+    result = Eloverblik(args.refresh_token).get_per_month(args.metering_point)
+    if result.status == 200:
+        print(f"Date: {result.data_date}")
+        for month in range(1, datetime.today().month + 1):
+            data = result.get_metering_data(month)
+            print(f"Month {month}: {data}kWh")
+
+        print(f"Total: {result.get_total_metering_data()}kWh")
     else:
         print(f"Error getting data. Status: {result.status}. Error: {result.detailed_status}")
 

--- a/pyeloverblik/__main__.py
+++ b/pyeloverblik/__main__.py
@@ -23,10 +23,10 @@ def main():
     if result.status == 200:
         total = 0
         print(f"Date: {result.data_date}")
-        for month in range(24):
-            data = result.get_metering_data(month)
+        for hour in range(24):
+            data = result.get_metering_data(hour)
             total += data
-            print(f"Hour {month}-{month+1}: {data}kWh")
+            print(f"Hour {hour}-{hour+1}: {data}kWh")
 
         print(f"Total: {total}kWh")
     else:

--- a/pyeloverblik/eloverblik.py
+++ b/pyeloverblik/eloverblik.py
@@ -4,6 +4,7 @@ Primary public module for eloverblik.dk API wrapper.
 from datetime import datetime
 from datetime import timedelta
 import json
+import re
 import requests
 import logging
 from .models import RawResponse
@@ -120,6 +121,35 @@ class Eloverblik:
             result = TimeSeries(raw_data.status, None, None, raw_data.body)
 
         return result
+
+    def get_per_month(self, metering_point, year=None):
+        '''
+        Get total consumption for each month in the given year, as well as the total for the year.
+        '''
+        if year is None:
+            year = datetime.today().year
+
+        if not re.match('\d{4}', str(year)):
+            raise ValueError("Year must be a four digit number.")
+
+        raw_data = self.get_time_series(metering_point,
+                                        from_date=datetime(year, 1, 1),
+                                        to_date=datetime(year, 12, 31) if year < datetime.today().year else datetime.today(),
+                                        aggregation='Month')
+        
+        if raw_data.status == 200:
+            json_response = json.loads(raw_data.body)
+
+            r = self._parse_result(json_response)
+            keys = list(r.keys())
+            keys.sort()
+
+            result = TimeSeries(raw_data.status, keys[-1], [r[k].get_total_metering_data() for k in keys])
+        else:
+            result = TimeSeries(raw_data.status, None, None, raw_data.body)
+
+        return result
+
 
     def _parse_result(self, result):
         '''

--- a/pyeloverblik/models.py
+++ b/pyeloverblik/models.py
@@ -44,13 +44,13 @@ class TimeSeries:
     def data_date(self):
         return self._data_date
     
-    def get_metering_data(self, hour):
+    def get_metering_data(self, index):
         '''
-        Get metering data for a single hour.
-        hour=1: data between 00.00 and 01.00.
-        hour=4: data between 03.00 and 04.00.
+        Get metering data for a single hour or hour.
+        index=1: data between 00.00 and 01.00 if TimeSeries contains day data, or January if TimeSeries contains month data.
+        index=4: data between 03.00 and 04.00 if TimeSeries contains day data, or April if TimeSeries contains month data.
         '''
-        return self._metering_data[hour-1]
+        return self._metering_data[index-1]
 
     def get_total_metering_data(self):
         total = 0

--- a/pyeloverblik/models.py
+++ b/pyeloverblik/models.py
@@ -46,7 +46,7 @@ class TimeSeries:
     
     def get_metering_data(self, index):
         '''
-        Get metering data for a single hour or hour.
+        Get metering data for a single hour or month.
         index=1: data between 00.00 and 01.00 if TimeSeries contains day data, or January if TimeSeries contains month data.
         index=4: data between 03.00 and 04.00 if TimeSeries contains day data, or April if TimeSeries contains month data.
         '''


### PR DESCRIPTION
This PR adds get_per_month to Eloverblik, to support the issues in homeassistant-eloverblik:

- https://github.com/JonasPed/homeassistant-eloverblik/issues/28
- https://github.com/JonasPed/homeassistant-eloverblik/issues/48

The first one asks for monthly usage data for the current and previous years, and the second one asks for total consumption for the current year. Both can be achieved by fetching monthly usage data for a given year, since the get_total_metering_data() on TimeSeries will return the sum of monthly usages, that is, the usage for the full year, and get_metering_data will return it for each month.

I realise I'm abusing _parse_data a bit here, but I wanted to change as little as possible in the current structure :)